### PR TITLE
New multipeer test branch

### DIFF
--- a/Appause/BluetoothManagerView.swift
+++ b/Appause/BluetoothManagerView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import MultipeerConnectivity
+import FirebaseAuth
 
 struct DiscoveredPeer: Identifiable {
     let id = UUID()
@@ -163,7 +164,7 @@ class BluetoothManager: NSObject, ObservableObject, MCSessionDelegate, MCNearbyS
     
     override init() {
         super.init()
-        peerID = MCPeerID(displayName: UIDevice.current.name)
+        peerID = MCPeerID(displayName: Auth.auth().currentUser?.email ?? "nil")
         mcSession = MCSession(peer: peerID, securityIdentity: nil, encryptionPreference: .required)
         mcSession.delegate = self
         

--- a/Appause/BluetoothManagerView.swift
+++ b/Appause/BluetoothManagerView.swift
@@ -152,12 +152,13 @@ struct BluetoothManagerView: View {
 }
 
 // BluetoothManager class
-class BluetoothManager: NSObject, ObservableObject, MCSessionDelegate, MCNearbyServiceBrowserDelegate {
+class BluetoothManager: NSObject, ObservableObject, MCSessionDelegate, MCNearbyServiceBrowserDelegate, MCNearbyServiceAdvertiserDelegate {
     @Published var discoveredPeers: [DiscoveredPeer] = []
     @Published var connectedPeers: [MCPeerID] = []
     private var peerID: MCPeerID!
     private var mcSession: MCSession!
     private var mcBrowser: MCNearbyServiceBrowser!
+    private var mcAdvertiser: MCNearbyServiceAdvertiser!
     private let serviceType = "admin-control"
     
     override init() {
@@ -168,6 +169,10 @@ class BluetoothManager: NSObject, ObservableObject, MCSessionDelegate, MCNearbyS
         
         mcBrowser = MCNearbyServiceBrowser(peer: peerID, serviceType: serviceType)
         mcBrowser.delegate = self
+        
+        mcAdvertiser = MCNearbyServiceAdvertiser(peer: peerID, discoveryInfo: nil, serviceType: serviceType)
+        mcAdvertiser.delegate = self
+        mcAdvertiser.startAdvertisingPeer()
     }
     
     // Start browsing for peers
@@ -230,6 +235,10 @@ class BluetoothManager: NSObject, ObservableObject, MCSessionDelegate, MCNearbyS
             self.discoveredPeers.removeAll { $0.peerID == peerID }
         }
     }
+    
+    func advertiser(_ advertiser: MCNearbyServiceAdvertiser, didReceiveInvitationFromPeer peerID: MCPeerID, withContext context: Data?, invitationHandler: @escaping (Bool, MCSession?) -> Void) {
+            invitationHandler(true, mcSession)
+        }
     
     // Empty implementations for other delegate methods
     func session(_ session: MCSession, didReceive data: Data, fromPeer peerID: MCPeerID) {}

--- a/Appause/Info.plist
+++ b/Appause/Info.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSLocalNetworkUsageDescription</key>
+        <string>We need access to your local network to discover nearby devices.</string>
+    <key>NSBonjourServices</key>
+    <array>
+        <string>_admin-control._tcp</string> <!-- This must match your service type in the app -->
+    </array>
+</dict>
+</plist>

--- a/Appause/TeacherMainView.swift
+++ b/Appause/TeacherMainView.swift
@@ -169,6 +169,11 @@ struct TeacherMainView: View {
                     Image(systemName: "gear")
                     Text("Settings")
                 }
+            BluetoothManagerView()
+                .tabItem {
+                    Image(systemName: "app.connected.to.app.below.fill")
+                    Text("Connectivity Manager")
+                }
         }
     }
 


### PR DESCRIPTION
Changed the setup of info.plist for the application to allow connection to a users network, a popup is presented to a given user the first time the app attempts to connect to the users network. Devices will now advertise as well as browse for other users. Also modified the displayName of devices to allow devices to be displayed using the same email address as the one associated with the account of the current user. 